### PR TITLE
Fix Markdown, add Header

### DIFF
--- a/src/heading.js
+++ b/src/heading.js
@@ -1,0 +1,22 @@
+/*
+  A generic heading block level element
+*/
+
+SirTrevor.Blocks.Heading = SirTrevor.Block.extend({ 
+
+  title: "Heading",             
+  className: "heading",  
+  limit: 0,
+  toolbarEnabled: true,         
+  dropEnabled: false,
+  formattingEnabled: false,
+
+  editorHTML: function() {
+		return _.template('<h2 class="required text-block <%= className %>" contenteditable="true"></h2>', this);
+	},
+
+	loadData: function(data){
+     this.$$('.text-block').html(data.text);
+  }
+
+});

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -33,8 +33,10 @@ SirTrevor.Blocks.Markdown = SirTrevor.Block.extend({
   
   toData: function() {
     var bl = this.$el,
-        dataStruct = bl.data('block');
+        dataObj = {}
     
-    dataStruct.data.text = this.$$('.markdown').val();
+    dataObj.text = this.$$('.markdown').val();
+
+		this.setData(dataObj)
   }
 });


### PR DESCRIPTION
Markdown's toData method was failing, fixed it.

Added a new generic Header block.
